### PR TITLE
Improve type alias prototype

### DIFF
--- a/lib/Type/Alias.pm
+++ b/lib/Type/Alias.pm
@@ -41,7 +41,6 @@ sub _import_type_alias_function {
 
         no strict qw(refs);
         no warnings qw(redefine); # Already define empty type alias at _import_type_aliases
-        no warnings qw(prototype); # Prototype mismatch: (;$) vs () or ($)
         *{"${target_package}::${type_alias_name}"} = generate_type_alias($type_alias_args);
     }
 }

--- a/t/Type-Alias/basic.t
+++ b/t/Type-Alias/basic.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 
-use Type::Alias -declare => [qw( X Y List )];
+use Type::Alias -alias => [qw( X Y )], -fun => [qw( List )];
 use Types::Standard -types;
 
 subtest 'type alias' => sub {
@@ -14,10 +14,7 @@ subtest 'type alias' => sub {
     is Y, Int;
 
     is X | Y, Str | Int;
-    TODO: {
-        local $TODO = '&X() & &Y() is not supported yet';
-        is X & Y, Str & Int;
-    }
+    is X & Y, Str & Int;
 };
 
 subtest 'type function' => sub {
@@ -33,12 +30,8 @@ subtest 'type function' => sub {
 };
 
 subtest 'type alias and type function' => sub {
-
     is X | List, Str | ArrayRef;
-    TODO: {
-        local $TODO = '&X() & &List() is not supported yet';
-        is X & List, Str & ArrayRef;
-    }
+    is X & List, Str & ArrayRef;
 };
 
 done_testing;

--- a/t/Type-Alias/basic.t
+++ b/t/Type-Alias/basic.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Type::Alias -declare => [qw( X Y List )];
+use Types::Standard -types;
+
+subtest 'type alias' => sub {
+
+    type X => Str;
+    type Y => Int;
+
+    is X, Str;
+    is Y, Int;
+
+    is X | Y, Str | Int;
+    TODO: {
+        local $TODO = '&X() & &Y() is not supported yet';
+        is X & Y, Str & Int;
+    }
+};
+
+subtest 'type function' => sub {
+
+    type List => sub {
+        my ($R) = @_;
+        $R ? ArrayRef[$R] : ArrayRef;
+    };
+
+    is List[Str], ArrayRef[Str];
+    is List[], ArrayRef;
+    is List, ArrayRef;
+};
+
+subtest 'type alias and type function' => sub {
+
+    is X | List, Str | ArrayRef;
+    TODO: {
+        local $TODO = '&X() & &List() is not supported yet';
+        is X & List, Str & ArrayRef;
+    }
+};
+
+done_testing;

--- a/t/Type-Alias/generate_type_alias.t
+++ b/t/Type-Alias/generate_type_alias.t
@@ -8,20 +8,19 @@ use Types::Standard -types;
 subtest 'If type constraint object is passed, return type alias coderef.' => sub {
     my $type_alias = Type::Alias::generate_type_alias(Int);
     is $type_alias->(), Int;
-
-    is prototype($type_alias), ';$';
-    eval { $type_alias->(1) };
-    ok $@, 'If type alias is not type function, cannot accept arguments';
+    is prototype($type_alias), '';
 };
 
 subtest 'If arrayref is passed, return Tuple type alias coderef.' => sub {
     my $type_alias = Type::Alias::generate_type_alias([Int, Str]);
     is $type_alias->(), Tuple[Int, Str];
+    is prototype($type_alias), '';
 };
 
 subtest 'If hashref is passed, return Dict type alias coderef.' => sub {
     my $type_alias = Type::Alias::generate_type_alias({ id => Int, name => Str });
     is $type_alias->(), Dict[id => Int, name => Str];
+    is prototype($type_alias), '';
 };
 
 subtest 'If coderef is passed, return type function coderef.' => sub {
@@ -32,6 +31,9 @@ subtest 'If coderef is passed, return type function coderef.' => sub {
 
     my $type_alias = Type::Alias::generate_type_alias($coderef);
     is $type_alias->([Int]), ArrayRef[Int];
+    is $type_alias->([]), ArrayRef;
+    is $type_alias->(), ArrayRef;
+    is prototype($type_alias), ';$';
 };
 
 done_testing;

--- a/t/Type-Alias/import.t
+++ b/t/Type-Alias/import.t
@@ -4,31 +4,55 @@ use Test::More;
 
 use Types::Standard qw(Str);
 
-subtest '-declare option predefine type aliases.' => sub {
+subtest '-alias option predefine type aliases.' => sub {
 
-    package TestOptionDeclare {
-        use Type::Alias -declare => [qw(Foo)];
+    package TestOptionAlias {
+        use Type::Alias -alias => [qw(Foo)];
     };
 
-    ok +TestOptionDeclare->can('Foo'), 'predefined Foo';
-    eval { TestOptionDeclare::Foo() };
+    ok +TestOptionAlias->can('Foo'), 'predefined Foo';
+    is prototype(\&TestOptionAlias::Foo), '', 'no argument';
+    eval { TestOptionAlias::Foo() };
     like $@, qr/should define type alias 'Foo'/;
 
     subtest 'If Alrealy exists same name function, cannot predeclare type alias.' => sub {
         eval '
-            package TestErrorDeclare {
+            package TestErrorAlias {
                 sub Foo { ... }
-                use Type::Alias -declare => [qw(Foo)];
+                use Type::Alias -alias => [qw(Foo)];
             };
         ';
-        like $@, qr/Cannot predeclare type alias 'TestErrorDeclare::Foo'/;
+        like $@, qr/Cannot predeclare type alias 'TestErrorAlias::Foo'/;
+    };
+};
+
+subtest '-fun option predefine type functions.' => sub {
+
+    package TestOptionFun {
+        use Type::Alias -fun => [qw(Foo)];
+    };
+
+    ok +TestOptionFun->can('Foo'), 'predefined Foo';
+    is prototype(\&TestOptionFun::Foo), ';$', 'argument is optional';
+
+    eval { TestOptionFun::Foo() };
+    like $@, qr/should define type function 'Foo'/;
+
+    subtest 'If Alrealy exists same name function, cannot predeclare type function.' => sub {
+        eval '
+            package TestErrorFun {
+                sub Foo { ... }
+                use Type::Alias -fun => [qw(Foo)];
+            };
+        ';
+        like $@, qr/Cannot predeclare type function 'TestErrorFun::Foo'/;
     };
 };
 
 subtest '-type_alias option specify type_alias function name, which default is `type`.' => sub {
 
     package TestOptionTypeAlias {
-        use Type::Alias -type_alias => 'mytype', -declare => [qw(Foo)];
+        use Type::Alias -type_alias => 'mytype', -alias => [qw(Foo)];
         use Types::Standard qw(Str);
 
         mytype Foo => Str;

--- a/t/Type-Alias/synopsis.t
+++ b/t/Type-Alias/synopsis.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 
-use Type::Alias -declare => [qw(ID User List)];
+use Type::Alias -alias => [qw(ID User)], -fun => [qw(List)];
 use Types::Standard -types;
 
 type ID => Str;

--- a/t/externals/Type-Tiny/basic.t
+++ b/t/externals/Type-Tiny/basic.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Requires qw( Types::Standard );
+
+use lib qw( ./t/externals/Type-Tiny/lib );
+
+use Sample qw( ID User List );
+use Types::Standard -types;
+
+subtest 'imported types' => sub {
+    is ID, Str;
+    is User, Dict[id => ID, name => Str, age => Int];
+    is List[User], ArrayRef[User];
+};
+
+subtest 'union operation' => sub {
+    is ID | Str, Str | Str;
+    is ID | ID, Str | Str;
+    is ID | List[Str], Str | ArrayRef[Str];
+    is List[Str] | List[Int], ArrayRef[Str] | ArrayRef[Int];
+
+    my $expected = Dict[id => ID, name => Str, age => Int] | ArrayRef[Dict[id => ID, name => Str, age => Int]];
+    is User | List[User], $expected;
+};
+
+subtest 'intersection operation' => sub {
+    is ID & Str, Str & Str;
+    is ID & ID, Str & Str;
+    is ID & List[Str], Str & ArrayRef[Str];
+    is List[Str] & List[Int], ArrayRef[Str] & ArrayRef[Int];
+
+    my $expected = Dict[id => ID, name => Str, age => Int] & ArrayRef[Dict[id => ID, name => Str, age => Int]];
+    is User & List[User], $expected;
+};
+
+done_testing;

--- a/t/externals/Type-Tiny/lib/Sample.pm
+++ b/t/externals/Type-Tiny/lib/Sample.pm
@@ -5,7 +5,7 @@ use warnings;
 our @EXPORT_OK = qw( hello world ID User List );
 
 use Type::Library -base, -declare => qw( Bar );
-use Type::Alias -declare => [qw( ID User List)];
+use Type::Alias -alias => [qw( ID User )], -fun => [qw( List )];
 use Types::Standard -types;
 
 sub hello { "HELLO" }

--- a/t/externals/Type-Tiny/lib/Sample.pm
+++ b/t/externals/Type-Tiny/lib/Sample.pm
@@ -1,0 +1,27 @@
+package Sample;
+use strict;
+use warnings;
+
+our @EXPORT_OK = qw( hello world ID User List );
+
+use Type::Library -base, -declare => qw( Bar );
+use Type::Alias -declare => [qw( ID User List)];
+use Types::Standard -types;
+
+sub hello { "HELLO" }
+sub world { "WORLD" }
+
+type ID => Str;
+
+type User => {
+    id   => ID,
+    name => Str,
+    age  => Int,
+};
+
+type List => sub {
+    my ($R) = @_;
+    $R ? ArrayRef[$R] : ArrayRef;
+};
+
+1;


### PR DESCRIPTION
This pull request is intended to adjust the prototypes of type functions and type aliases. Specifically, `;$` is set as the prototype for type functions and `''` for type aliases.

## Problem / Background

The prototype for type aliases is currently `;$`. However, this leads to unintended interpretation in scenarios such as:

```perl
use Type::Alias -declare => [qw( X Y )];

type X => Str;
type Y => Str;

X & Y; // This is interpreted as &X(scalar &Y) instead of &X() & &Y().
```

## Solution

The solution involves differentiating the prototype based on whether it's a type function or a type alias. Specifically, the -declare option is eliminated, and new options, -alias and -fun, are introduced. This adjustment modifies the usage of Type::Alias as follows:

```perl
use Type::Alias -alias => [qw(X Y)], -fun => [qw(List)];

type X => Str;
type Y => Str;
type List => sub ($R) {
   ArrayRef[$R]
};
```
Through these changes, the program can distinguish between type functions and type aliases, thus avoiding unintentional interpretations.