### PR TITLE
add `type` option and remove `-type_alias` option

### DIFF
--- a/t/Type-Alias/import.t
+++ b/t/Type-Alias/import.t
@@ -49,15 +49,15 @@ subtest '-fun option predefine type functions.' => sub {
     };
 };
 
-subtest '-type_alias option specify type_alias function name, which default is `type`.' => sub {
+subtest '-opts option specifies just a few options for Type::Alias.' => sub {
 
-    package TestOptionTypeAlias {
-        use Type::Alias -type_alias => 'mytype', -alias => [qw(Foo)];
+    package TestRenameType {
+        use Type::Alias type => { -as => 'mytype' }, -alias => [qw(Foo)];
         use Types::Standard qw(Str);
 
         mytype Foo => Str;
     };
-    is TestOptionTypeAlias::Foo, Str;
+    is TestRenameType::Foo, Str;
 
     eval '
         package TestErrorTypeAlias {


### PR DESCRIPTION
This pull request provides `type` option and remove `-type_alias` option.

```perl
# BEFORE
use Type::Alias -type_alias => 'mytype', -alias => [qw(Foo)]

# AFTER
use Type::Alias type => { -as => 'mytype' }, -alias => [qw(Foo)]
```

## Background

The introduction of the -alias option in the following pull request has led to confusion with the -type_alias name.
- https://github.com/kfly8/Type-Alias/pull/3

## Reason

The reason for choosing the option name `type` is because it is an option for modifying the `type` function. Moreover, options like `-alias` or `-fun` are intended for non-function usage, and the presence or absence of a hyphen is used to distinguish whether the option is for functions or not.
