### PR TITLE
Convert scalar value to Eq,NumEq,Undef,Bool

### DIFF
--- a/META.json
+++ b/META.json
@@ -43,6 +43,7 @@
       "runtime" : {
          "requires" : {
             "Type::Tiny" : "1.010002",
+            "Types::Equal" : "0.02",
             "perl" : "5.020000"
          }
       },

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'perl', '5.020000';
 
 requires 'Type::Tiny', '1.010002';
+requires 'Types::Equal', '0.02';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/lib/Type/Alias.pm
+++ b/lib/Type/Alias.pm
@@ -200,40 +200,51 @@ Type::Alias - type alias for type constraints
 
 =head1 SYNOPSIS
 
-    use Type::Alias -alias => [qw(ID User UserData)], -fun => [qw(List)];
     use Types::Standard -types;
+    use Type::Alias
+        -alias => [qw(ID User Guest LoginUser UserList)],
+        -fun => [qw(List)];
 
     type ID => Str;
 
-    type User => {
+    type LoginUser => {
+        _type => 'LoginUser',
         id   => ID,
         name => Str,
         age  => Int,
     };
+
+    type Guest => {
+        _type => 'Guest',
+        name => Str,
+    };
+
+    type User => LoginUser | Guest;
 
     type List => sub {
         my ($R) = @_;
         $R ? ArrayRef[$R] : ArrayRef;
     };
 
-    type UserData => List[User] | User;
+    type UserList => List[User];
 
-    UserData->check([
-        { id => '1', name => 'foo', age => 20 },
-        { id => '2', name => 'bar', age => 30 },
-    ]); # OK
+    UserList->check([
+        { _type => 'LoginUser', id => '1', name => 'foo', age => 20 },
+        { _type => 'Guest', name => 'bar' },
+    ]); # => OK
 
-    UserData->check(
-        { id => '1', name => 'foo', age => 20 },
-    ); # OK
-
-    # Internally List[User] is equivalent to the following type:
+    # Internally UserList is equivalent to the following type:
     #
     # ArrayRef[
     #     Dict[
-    #         age=>Int,
-    #         id=>Str,
-    #         name=>Str
+    #         _type => Eq['LoginUser'],
+    #         age => Int,
+    #         id => Str,
+    #         name => Str
+    #     ] |
+    #     Dict[
+    #         _type => Eq['Guest'],
+    #         name => Str
     #     ]
     # ]
 
@@ -280,8 +291,10 @@ The C<type> option is used to configure the type function that defines type alia
 
 =head3 type($alias_name, $type_args)
 
-C<type> is a function that defines type alias and type function.
+C<type> is a function that defines a type alias and a type function.
 It recursively generates type constraints based on C<$type_args>.
+
+=head4 C<$type_args> is a type constraint
 
 Given a type constraint in C<$type_args>, it returns the type constraint as is.
 Type::Alias treats objects with C<check> and C<get_message> methods as type constraints.
@@ -293,6 +306,59 @@ Type::Alias treats objects with C<check> and C<get_message> methods as type cons
 Internally C<ID> is equivalent to the following type:
 
     sub ID() { Str }
+
+=head4 C<$type_args> is an undefined value
+
+Given a undefined value in C<$type_args>, it returns the type constraint defined by Type::Tiny's Undef type.
+
+    type Foo => Undef;
+
+    Foo->check(undef); # OK
+
+Internally C<Foo> is equivalent to the following type:
+
+    sub Foo() { Undef }
+
+=head4 C<$type_args> is a string value
+
+Given a string value in C<$type_args>, it returns the type constraint defined by L<Types::Equal::Eq> type.
+
+    type ID => 'foo';
+
+    ID->check('foo'); # OK
+
+    type Published => 'published';
+    type Draft => 'draft';
+    type Status => Published | Draft;
+
+    Status->check('published'); # ok
+    Status->check('draft'); # ok
+
+Internally C<Status> is equivalent to the following type:
+
+    sub Status() { Eq['published'] | Eq['draft'] }
+
+=head4 C<$type_args> is a number value
+
+B<Available at v5.36 above. Less than v5.36, converts to Eq.>
+
+Given a number value in C<$type_args>, it returns the type constraint defined by L<Types::Equal::NumEq> type.
+
+    type Foo => 123;
+    # Foo is NumEq[123]; v5.36 above
+    # Foo is Eq[123]; # less than v5.36
+
+=head4 C<$type_args> is a boolean value
+
+B<Available at v5.36 above. Less than v5.36, converts to Eq.>
+
+Given a boolean value in C<$type_args>, it returns the type constraint defined by Type::Tiny's Bool type.
+
+    type Foo => !!1;
+    # Foo is Type::Alias::True; v5.36 above
+    # Foo is Eq[!!1]; # less than v5.36
+
+=head4 C<$type_args> is a hash reference
 
 Given a hash reference in C<$type_args>, it returns the type constraint defined by Type::Tiny's Dict type.
 
@@ -310,6 +376,8 @@ Internally C<Point> is equivalent to the following type:
 
     sub Point() { Dict[x=>Int,y=>Int] }
 
+=head4 C<$type_args> is an array reference
+
 Given an array reference in C<$type_args>, it returns the type constraint defined by Type::Tiny's Tuple type.
 
     type Option => [Str, Int];
@@ -320,7 +388,9 @@ Internally C<Option> is equivalent to the following type:
 
     sub Option() { Tuple[Str,Int] }
 
-Given a code reference in C<$type_args>, it defines a type function that accepts a type constraint as an argument and return the type constraint.
+=head4 C<$type_args> is a code reference
+
+Given a code reference in C<$type_args>, it defines a type function that accepts a type constraint as an argument and returns the type constraint.
 
     type List => sub($R) {
        $R ? ArrayRef[$R] : ArrayRef;

--- a/lib/Type/Alias.pm
+++ b/lib/Type/Alias.pm
@@ -163,8 +163,12 @@ sub _to_type_scalar {
         }
     }
     else {
-        # TODO: Is it better to make it a type that checks whether it matches the given value?
-        croak 'This value is not supported: ' . (defined $v ? $v : 'undef');
+        if (!defined $v) {
+            return Undef;
+        }
+        else { # string, number, bool
+            Eq[$v];
+        }
     }
 }
 

--- a/t/Type-Alias/synopsis.t
+++ b/t/Type-Alias/synopsis.t
@@ -2,31 +2,52 @@ use strict;
 use warnings;
 use Test::More;
 
-use Type::Alias -alias => [qw(ID User UserData)], -fun => [qw(List)];
 use Types::Standard -types;
+use Type::Alias
+    -alias => [qw(ID User Guest LoginUser UserList)],
+    -fun => [qw(List)];
 
 type ID => Str;
 
-type User => {
+type LoginUser => {
+    _type => 'LoginUser',
     id   => ID,
     name => Str,
     age  => Int,
 };
+
+type Guest => {
+    _type => 'Guest',
+    name => Str,
+};
+
+type User => LoginUser | Guest;
 
 type List => sub {
     my ($R) = @_;
     $R ? ArrayRef[$R] : ArrayRef;
 };
 
-type UserData => List[User] | User;
+type UserList => List[User];
 
-ok UserData->check([
-    { id => '1', name => 'foo', age => 20 },
-    { id => '2', name => 'bar', age => 30 },
+ok UserList->check([
+    { _type => 'LoginUser', id => '1', name => 'foo', age => 20 },
+    { _type => 'Guest', name => 'bar' },
 ]);
 
-ok UserData->check(
-    { id => '1', name => 'foo', age => 20 },
-);
+is UserList->display_name, <<'EXPECTED' =~ s/\s//gr;;
+    ArrayRef[
+        Dict[
+            _type => Eq['LoginUser'],
+            age => Int,
+            id => Str,
+            name => Str
+        ] |
+        Dict[
+            _type => Eq['Guest'],
+            name => Str
+        ]
+    ]
+EXPECTED
 
 done_testing;

--- a/t/Type-Alias/to_type.t
+++ b/t/Type-Alias/to_type.t
@@ -101,15 +101,24 @@ if (Type::Alias::AVAILABLE_BUILTIN) {
     };
 }
 else {
-    subtest 'If scalar is passed, throw error.' => sub {
-        eval { Type::Alias::to_type('hello') };
-        ok $@, 'does not support string';
+    subtest 'If undef is passed, return Undef type.' => sub {
+        is Type::Alias::to_type(undef), Undef;
+    };
 
-        eval { Type::Alias::to_type(!!1) };
-        ok $@, 'does not support boolean';
+    subtest 'If boolean is passed, return Eq type.' => sub {
+        is Type::Alias::to_type(!!1), Eq[!!1];
+        is Type::Alias::to_type(!!0), Eq[!!0];
+    };
 
-        eval { Type::Alias::to_type(undef) };
-        ok $@, 'does not support undef';
+    subtest 'If number is passed, return Eq type.' => sub {
+        is Type::Alias::to_type(123), Eq[123];
+        is Type::Alias::to_type(0), Eq[0];
+    };
+
+    subtest 'If string is passed, return Eq type.' => sub {
+        is Type::Alias::to_type('hello'), Eq['hello'];
+        is Type::Alias::to_type('123'), Eq['123'];
+        is Type::Alias::to_type(''), Eq[''];
     };
 }
 

--- a/t/Type-Alias/to_type.t
+++ b/t/Type-Alias/to_type.t
@@ -4,6 +4,7 @@ use Test::More;
 
 use Type::Alias ();
 use Types::Standard -types;
+use Types::Equal -types;
 
 package MyType {
     sub new { bless {}, shift }
@@ -78,18 +79,38 @@ subtest 'If regexref is passed, throw error.' => sub {
     ok $@;
 };
 
-subtest 'If scalar is passed, throw error.' => sub {
-    eval { Type::Alias::to_type(123) };
-    ok $@, 'does not support number';
+if (Type::Alias::AVAILABLE_BUILTIN) {
+    subtest 'If undef is passed, return Undef type.' => sub {
+        is Type::Alias::to_type(undef), Undef;
+    };
 
-    eval { Type::Alias::to_type('hello') };
-    ok $@, 'does not support string';
+    subtest 'If boolean is passed, return Boolean type.' => sub {
+        is Type::Alias::to_type(!!1), Type::Alias::True;
+        is Type::Alias::to_type(!!0), Type::Alias::False;
+    };
 
-    eval { Type::Alias::to_type(!!1) };
-    ok $@, 'does not support boolean';
+    subtest 'If number is passed, return NumEq type.' => sub {
+        is Type::Alias::to_type(123), NumEq[123];
+        is Type::Alias::to_type(0), NumEq[0];
+    };
 
-    eval { Type::Alias::to_type(undef) };
-    ok $@, 'does not support undef';
-};
+    subtest 'If string is passed, return Eq type.' => sub {
+        is Type::Alias::to_type('hello'), Eq['hello'];
+        is Type::Alias::to_type('123'), Eq['123'];
+        is Type::Alias::to_type(''), Eq[''];
+    };
+}
+else {
+    subtest 'If scalar is passed, throw error.' => sub {
+        eval { Type::Alias::to_type('hello') };
+        ok $@, 'does not support string';
+
+        eval { Type::Alias::to_type(!!1) };
+        ok $@, 'does not support boolean';
+
+        eval { Type::Alias::to_type(undef) };
+        ok $@, 'does not support undef';
+    };
+}
 
 done_testing;

--- a/t/externals/Type-Utils/basic.t
+++ b/t/externals/Type-Utils/basic.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Requires qw( Type::Utils );
+
+use Type::Utils qw( compile_match_on_type );
+use Type::Alias -alias => [qw/ Published Draft /];
+
+type Published => 'published';
+type Draft     => 'draft';
+
+subtest 'pattern matching' => sub {
+
+    my $hi = compile_match_on_type(
+        Published, sub { 'published!' },
+        Draft, sub { 'draft...' }
+    );
+
+    is $hi->('published'), 'published!';
+    is $hi->('draft'), 'draft...';
+
+    eval { $hi->('foo') };
+    ok $@;
+};
+
+done_testing;


### PR DESCRIPTION
This pull request provides converting scalar value to [Eq](https://metacpan.org/pod/Types::Equal#Eq), [NumEq](https://metacpan.org/pod/Types::Equal#NumEq),  Types::Standard::Undef, Types::Standard::Bool:  

### Undef value

```perl
type Foo => undef;
# => Foo is Types::Standard::Undef
```

### String value

```perl
type Published => 'published';
type Draft => 'draft';
type Status => Published | Draft;

Status->check('published'); # ok
Status->check('draft'); # ok

# Status is Eq['published'] | Eq['draft']
```

### Number value

Available at v5.36 above. Less than v5.36, converts to Eq.

```perl
type Foo => 123;
# Foo is NumEq[123]; v5.36 above
# Foo is Eq[123]; # less than v5.36
```

### Bool value

Available at v5.36 above. Less than v5.36, converts to Eq.

```perl
type Foo => !!1;
# Foo is True; v5.36 above
# Foo is Eq[!!1]; # less than v5.36
```
